### PR TITLE
Data run mod

### DIFF
--- a/ta2_hrr_analysisCode/HASOAnalysis.py
+++ b/ta2_hrr_analysisCode/HASOAnalysis.py
@@ -307,7 +307,7 @@ def intgrad2(fx,fy,X,Y,f00):
 	Tmp = A.toarray()[:,0]
 
 	Tmp = Tmp.flatten()
-	print(np.shape(f00))
+	
 	rhs = rhs - Tmp*f00
 	
 	X = lsqr(A, rhs)

--- a/ta2_hrr_analysisCode/dataRun.py
+++ b/ta2_hrr_analysisCode/dataRun.py
@@ -10,7 +10,7 @@ import glob
 from pathlib import Path
 
 try:
-	import cPickle as pickle
+	import cPickle as pickle # only for python2
 except ModuleNotFoundError:
 	import pickle
 from datetime import datetime
@@ -215,13 +215,13 @@ class dataRun:
 	def collectSQLData(self):
 		analysisPath,isItReal = self.getDiagAnalysisPath('General')
 		gasCellCsvFilePath = os.path.join(analysisPath,'GasCell.csv')
+		runName = self.runName
+		runDate = self.runDate
 		if os.path.isfile(gasCellCsvFilePath):
 			gasCell_df = pd.read_csv(gasCellCsvFilePath)
 		else:
-			from sqlDatabase import connectToSQL
+			from .sqlDatabase import connectToSQL
 			db = connectToSQL(True)
-			runName = self.runName
-			runDate = self.runDate
 			keys = ['run','shot_or_burst','GasCellPressure','GasCellLength']
 
 			# Get all data pertaining to the run
@@ -253,7 +253,7 @@ class dataRun:
 	# PROBE ANALYSIS
 	def performProbeDensityAnalysis(self, overwrite = True, verbose = False, visualise = False, 
 				Debugging = False):
-		import probe_density_extraction 
+		from . import probe_density_extraction 
 		diag = 'Probe_Interferometry'
 		print ("In ", diag)
 
@@ -290,7 +290,7 @@ class dataRun:
 	def performESpecAnalysis(self,useCalibration=True,overwriteData=False):
 		# Load the espec images for the run and analyse
 		# if it exists get it, if not, run initESpecAnalysis and update log
-		import ESpecAnalysis
+		from . import ESpecAnalysis
 		diag = 'HighESpec'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)
@@ -316,7 +316,7 @@ class dataRun:
 
 	# SPIDER ANALYSIS CALLS 
 	def performSPIDERAnalysis(self):
-		import SPIDERAnalysis
+		from . import SPIDERAnalysis
 		diag = 'SPIDER'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)
@@ -339,7 +339,7 @@ class dataRun:
 
 	# HASO Analysis
 	def performHASOAnalysis(self,useChamberCalibration=True,getIndividualShots=False,overwriteAnalysis=True):
-		import HASOAnalysis
+		from . import HASOAnalysis
 		diag = 'HASO'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)
@@ -388,7 +388,7 @@ class dataRun:
 
 	# PRE COMP NF (BEAM ENERGY) Anlaysis
 	def performPreCompNFAnalysis(self):
-		import PreCompNFAnalysis
+		from . import PreCompNFAnalysis
 		diag = 'PreCompNF'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)
@@ -416,7 +416,7 @@ class dataRun:
 
 	# X-Ray Anlaysis
 	def performXRayAnalysis(self,justGetCounts=False):
-		import XRayAnalysis 
+		from . import XRayAnalysis 
 		diag = 'XRay'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)

--- a/ta2_hrr_analysisCode/dataRun.py
+++ b/ta2_hrr_analysisCode/dataRun.py
@@ -16,12 +16,12 @@ except ModuleNotFoundError:
 from datetime import datetime
 
 # IMPORT DIAGNOSTIC CODES
-import SPIDERAnalysis
-import HASOAnalysis
-import ESpecAnalysis
-import PreCompNFAnalysis
-import XRayAnalysis 
-import probe_density_extraction 
+
+
+
+
+
+
 
 
 class dataRun:
@@ -70,7 +70,6 @@ class dataRun:
 			loggingAnalysisFolder 	= self.createAnalysisFolder()
 			self.loggerFile 		= oldRun.loggerFile
 			self.logThatShit('Analysis Continued\n')
-			
 
 			self.diagList 			= oldRun.diagList
 			self.datStyle 			= oldRun.datStyle
@@ -111,8 +110,6 @@ class dataRun:
 
 			# Collect SQL Data
 			self.collectSQLData()
-
-
 
 	def findAvailableDiagnostics(self,runDate,runName):
 		'''
@@ -215,7 +212,6 @@ class dataRun:
 				print('\n\nGeneral Analysis folder already exists\n{}\n'.format(analysisPath))
 		return(analysisPath)
 
-
 	def collectSQLData(self):
 		db = connectToSQL(True)
 		runName = self.runName
@@ -241,9 +237,6 @@ class dataRun:
 		self.saveData(os.path.join(analysisPath,'gasCellLength'),gasCellLength)
 
 
-
-
-
 	# -------------------------------------------------------------------------------------------------------------------
 	# -----										DIAGNOSTIC FUNCTION CALLS 											-----
 	# -------------------------------------------------------------------------------------------------------------------
@@ -251,6 +244,7 @@ class dataRun:
 	# PROBE ANALYSIS
 	def performProbeDensityAnalysis(self, overwrite = True, verbose = False, visualise = False, 
 				Debugging = False):
+		import probe_density_extraction 
 		diag = 'Probe_Interferometry'
 		print ("In ", diag)
 
@@ -287,6 +281,7 @@ class dataRun:
 	def performESpecAnalysis(self,useCalibration=True,overwriteData=False):
 		# Load the espec images for the run and analyse
 		# if it exists get it, if not, run initESpecAnalysis and update log
+		import ESpecAnalysis
 		diag = 'HighESpec'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)
@@ -310,10 +305,9 @@ class dataRun:
 			self.logThatShit('Performed HighESpec Analysis for ' + burstStr)
 			print('Analysed ESpec Spectrum, Charge, totalEnergy, cutoffEnergy95 for Burst '+ burstStr)
 
-
-
-	# SPIDER ANALYSIS CALLS -- THIS IS CURRENTLY JUST AN EXAMPLE
+	# SPIDER ANALYSIS CALLS 
 	def performSPIDERAnalysis(self):
+		import SPIDERAnalysis
 		diag = 'SPIDER'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)
@@ -334,10 +328,9 @@ class dataRun:
 			print('Analysed SPIDER '+ burstStr)
 		return 0
 
-
-
 	# HASO Analysis
 	def performHASOAnalysis(self,useChamberCalibration=True,getIndividualShots=False,overwriteAnalysis=True):
+		import HASOAnalysis
 		diag = 'HASO'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)
@@ -384,9 +377,9 @@ class dataRun:
 			self.logThatShit('Performed HASO Analysis for ' + burstStr)
 			print('Analysed HASO '+ burstStr)
 
-
 	# PRE COMP NF (BEAM ENERGY) Anlaysis
 	def performPreCompNFAnalysis(self):
+		import PreCompNFAnalysis
 		diag = 'PreCompNF'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)
@@ -412,9 +405,9 @@ class dataRun:
 			print('Performed NF Analysis for ' + burstStr +'. Avg Pulse Energy On Target = ' +  energyStr)
 		return 0	
 
-
 	# X-Ray Anlaysis
 	def performXRayAnalysis(self,justGetCounts=False):
+		import XRayAnalysis 
 		diag = 'XRay'
 		filePathDict = self.createRunPathLists(diag)
 		analysisPath, pathExists = self.getDiagAnalysisPath(diag)


### PR DESCRIPTION
I removed the need for SQL except on the first execution. All the sql data is stored as a csv in the analysis folder and then loaded as needed if it is there. Could in a further step remove sql code altogether and just ship this file with the analysis package.  It's only <1MB.

Also, I moved some of the imports for diagnostics inside their functions which might help using dataRun on certain diagnostics without the need to import the code for all the others.

